### PR TITLE
Added updated cascading delete rules for artists, albums, and songs

### DIFF
--- a/models/album.py
+++ b/models/album.py
@@ -2,10 +2,14 @@ from mongoengine import Document, StringField, IntField, ReferenceField, ListFie
 
 class Album(Document):
     album_name = StringField(required=True)
-    # artists = ListField(ReferenceField('Artist'), default=list)
+    artists = ListField(ReferenceField('Artist'), default=list)
     release_year = IntField(default=2020)
-    # song_listing = ListField(ReferenceField('Song'), default=list)
+    song_listing = ListField(ReferenceField('Song'), default=list)
     genre = StringField(default='rock')
     meta = {
         'collection': 'albums'
     }
+
+
+
+#print("Album model loaded:", Album._fields)

--- a/models/artist.py
+++ b/models/artist.py
@@ -3,8 +3,8 @@ from mongoengine import Document, StringField, IntField, ListField, ReferenceFie
 class Artist(Document):
     artist_name = StringField(required=True)
     country_of_origin = StringField()
-    # songs_credited = ListField(ReferenceField('Song'), default=list)
-    # albums_credited = ListField(ReferenceField('Album'), default=list)
+    songs_credited = ListField(ReferenceField('Song'), default=list)
+    albums_credited = ListField(ReferenceField('Album'), default=list)
     age = IntField(default=35)
     genres = ListField(StringField(), default=list)
     label = StringField()

--- a/models/song.py
+++ b/models/song.py
@@ -1,9 +1,9 @@
-from mongoengine import Document, StringField, IntField, ReferenceField
+from mongoengine import Document, StringField, IntField, ListField, ReferenceField
 
 class Song(Document):
     song_name = StringField(required=True)
-    # artists = ListField(ReferenceField('Artist'), default=list)
-    # albums = ListField(ReferenceField('Album'), default=list)
+    artists = ListField(ReferenceField('Artist'), default=list)
+    albums = ListField(ReferenceField('Album'), default=list)
     song_length = IntField(default=0)
     meta = {
         'collection': 'songs'

--- a/routes/artist_routes.py
+++ b/routes/artist_routes.py
@@ -69,12 +69,41 @@ def create_artist():
 @artist_bp.route("/artists/<id>", methods=["DELETE"])
 def delete_artist(id):
     """ Endpoint for deleting an artist """
+    from models.album import Album
+    from models.song import Song
+
     try:
         artist = Artist.objects(id=ObjectId(id)).first()
         if not artist:
             return jsonify({"error": "Artist not found"}), 404
+        
+        #find all albums that reference this artist
+        albums_with_artist = Album.objects(artists=artist)
+        for album in albums_with_artist:
+            #remove the artist from the album's artist list
+            album.update(pull__artists=artist)
+
+            #fetch the album object, to see updated artists list
+            updated_album = Album.objects(id=album.id).first()
+
+            #if no more artists in that album, delete the album
+            if not updated_album.artists:
+                #before deleting the album, remove it from all songs referencing it
+                songs_with_album = Song.objects(albums=album)
+                for song in songs_with_album:
+                    song.update(pull__albums=album)
+                    #fetch updated song, if now empty, delete the song
+                    updated_song = Song.objects(id=song.id).first()
+                    if not updated_song.albums:
+                        updated_song.delete()
+
+                #delete the album
+                updated_album.delete() 
+        
+        #delete the artist
         artist.delete()
-        return jsonify({"message": "Artist deleted successfully"}), 200
+        return jsonify({"message": f"Artist '{artist.artist_name}' deleted. Albums with no remaining artists also removed."}), 200
+
     except bson_errors.InvalidId:
         return jsonify({"error": "Invalid ID format"}), 400
     except DoesNotExist:


### PR DESCRIPTION
Added new delete rules for artists and albums delete routes. If deleting an artist, it will also delete any albums it is associated with (if it is the last artist associated with the album) and any songs associated with that album (if it is the last album associated with the song). Additionally, added the same rule in the albums delete routes to also delete all songs associated with the album (if it's the last album associated with the song). Currently our project is set up as Many-to-Many such as an album can be linked to multiple artists and a song can be linked to multiple albums. The updated delete rules account for this but will have to be slightly changed if we switch to a one-to-many approach. Also I tested the logic with Postman and it seemed to work as intended.